### PR TITLE
EDATA-8207 # build our own image with K8S-secret for users creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # atlas-helm-chart
 This chart will install the apache atlas and used solr for indexing and cassandra as backend storage.
 
-To install the chart. clone the repo and run following command to install chart
+To install the chart. clone the repo. Create Secret for users credentials
+
+```sh
+kubectl create -f secret.yaml
+```
+
+Finally, run following command to install chart
 
 ```sh
 helm install --name <any release name> -f atlas-helm-chart/values.yaml atlas-helm-chart

--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ mvn clean -DskipTests install
 mvn clean -DskipTests package -Pdist
 ```
 This will Generate tar file of Apache atlas
+
+## Build Docker image
+docker build -t "gcr.io/edw-dev/apache-atlas:1.1.0" .
+gcloud docker -- push gcr.io/edw-dev/apache-atlas:1.1.0

--- a/secret.yaml
+++ b/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: atlas-zendesk-users-credentials
+type: Opaque
+data:
+  users-credentials.properties: YWRtaW49QURNSU46OmRkOGZjZTc4OWZjZWFkNDJmOGI0NjM1ZmZmZTllYTBhMWJmNzAwYzI3MTdhY2Q1NWY1ODhjMTRkMTBkNGMzZjIK

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -53,7 +53,7 @@ data:
 
     atlas.authentication.method.ldap.type=none
 
-    atlas.authentication.method.file.filename=${sys:atlas.home}/conf/users-credentials.properties
+    atlas.authentication.method.file.filename=/etc/conf/users-credentials.properties
 
 
     atlas.rest.address=http://localhost:21000

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -53,9 +53,15 @@ spec:
           volumeMounts:
           - name: atlas-config
             mountPath: /apache-atlas-1.1.0/conf/atlas-application.properties
-            subPath: atlas-application.properties            
+            subPath: atlas-application.properties
+          - name: atlas-users
+            readOnly: true
+            mountPath: "/etc/conf"
       volumes:
       - name: atlas-config
         configMap:
-          name: atlas-config               
+          name: atlas-config 
+      - name: atlas-users
+        secret:
+          secretName: atlas-zendesk-users-credentials
 

--- a/values.yaml
+++ b/values.yaml
@@ -3,8 +3,8 @@
 # Declare variables to be passed into your templates.
 replicaCount: 1
 image:
-  repository: xmavrck/atlas
-  tag: latest
+  repository: gcr.io/edw-dev/apache-atlas
+  tag: 1.1.0
   pullPolicy: IfNotPresent
 config_parameter:
   cassandra_clustername: cassandra


### PR DESCRIPTION
* Build our own image, host it on GCR and use it in deployment.yaml
* Enable hard-delete in configuration
* Set users credentials file to /etc/conf which is mounted to a K8S secret